### PR TITLE
feat: add robots.txt generator plugin for better SEO

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -97,6 +97,7 @@ const config: QuartzConfig = {
       Plugin.Static(),
       Plugin.NotFoundPage(),
       Plugin.CNAME(), // Needed for github pages
+      Plugin.RobotsTxt(),
     ],
   },
 }

--- a/quartz/plugins/emitters/robotsTxt.ts
+++ b/quartz/plugins/emitters/robotsTxt.ts
@@ -1,0 +1,26 @@
+import { QuartzEmitterPlugin } from "../types"
+import path from "path"
+import fs from "fs/promises"
+import { FilePath } from "../../util/path"
+
+export const RobotsTxt: QuartzEmitterPlugin = () => {
+  return {
+    name: "RobotsTxt",
+    getQuartzComponents() {
+      return []
+    },
+    async emit({ argv, cfg }): Promise<FilePath[]> {
+      const baseUrl = cfg.configuration.baseUrl ? `https://${cfg.configuration.baseUrl}` : ""
+      const robotsTxtContent: string = `User-agent: *
+Allow: /
+
+# Sitemap
+Sitemap: ${baseUrl}/sitemap.xml
+`
+
+      const outputPath = path.join(argv.output, "robots.txt")
+      await fs.writeFile(outputPath, robotsTxtContent, "utf-8")
+      return [outputPath as FilePath]
+    },
+  }
+} 

--- a/quartz/plugins/index.ts
+++ b/quartz/plugins/index.ts
@@ -41,6 +41,7 @@ export function getStaticResourcesFromPlugins(ctx: BuildCtx) {
 export * from "./transformers"
 export * from "./filters"
 export * from "./emitters"
+export { RobotsTxt } from "./emitters/robotsTxt"
 
 declare module "vfile" {
   // inserted in processors.ts


### PR DESCRIPTION
This PR adds a robots.txt generator plugin to improve SEO capabilities: - Creates a new RobotsTxt emitter plugin - Generates robots.txt file during build process - Allows all search engines to crawl the site - Points to the sitemap.xml for better indexing - Integrates with existing ContentIndex plugin's sitemap generation