### PR TITLE
feat: switch to ExplicitPublish and improve documentation

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -8,6 +8,7 @@
 ## Workflow
 - Pull before work: repo changes frequently
 - Create PR -> merge to v4
+  - Prefer using CLI for PR creation and merging: `gh pr create` and `gh pr merge`
 - GitHub Actions deploys to gh-pages on v4 branch pushes
 - Submodules need recursive update after pull
 

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -81,7 +81,7 @@ const config: QuartzConfig = {
       Plugin.Latex({ renderEngine: "katex" }),
     ],
     filters: [
-      Plugin.RemoveDrafts(),
+      Plugin.ExplicitPublish(),
     ],
     emitters: [
       Plugin.AliasRedirects(),


### PR DESCRIPTION
## Changes\n\n1. Switched from RemoveDrafts to ExplicitPublish filter\n   - Now pages are published only when explicitly marked with `publish: true` in frontmatter\n   - This provides better control over what content gets published\n   - Default state is private (not published)\n\n2. Updated .cursorrules documentation\n   - Added recommendation to use GitHub CLI for PR operations\n   - Specified commands: `gh pr create` and `gh pr merge`\n\n## How to use\n\nTo publish a page, add to its frontmatter:\n```yaml\n---\npublish: true\n---\n```\n\nPages without this flag will remain private.\n\n## Testing\n\n- [ ] Verify that pages without `publish: true` are not published\n- [ ] Verify that pages with `publish: true` are published\n- [ ] Check that the documentation is clear and helpful