### PR TITLE
feat: improve tag pages SEO

### DIFF
--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -73,8 +73,8 @@ export default {
         count === 1 ? "1 item under this folder." : `${count} items under this folder.`,
     },
     tagContent: {
-      tag: "Tag",
-      tagIndex: "Tag Index",
+      tag: "Articles about",
+      tagIndex: "All Tags",
       itemsUnderTag: ({ count }) =>
         count === 1 ? "1 item with this tag." : `${count} items with this tag.`,
       showingFirst: ({ count }) => `Showing first ${count} tags.`,

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -62,7 +62,7 @@ function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
     .map(tag => {
       const tagSlug = `tags/${tag}` as SimpleSlug
       return createURLEntry(tagSlug, {
-        title: `Tag: ${tag}`,
+        title: `${cfg.pageTitle}: ${i18n(cfg.locale).pages.tagContent.tag} ${tag}`,
         links: [],
         tags: [],
         content: "",
@@ -73,7 +73,7 @@ function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
 
   // Add the main tags index page
   const tagsIndexUrl = createURLEntry("tags/" as SimpleSlug, {
-    title: "Tags",
+    title: `${cfg.pageTitle}: ${i18n(cfg.locale).pages.tagContent.tagIndex}`,
     links: [],
     tags: [],
     content: "",

--- a/quartz/plugins/emitters/contentIndex.ts
+++ b/quartz/plugins/emitters/contentIndex.ts
@@ -2,7 +2,7 @@ import { Root } from "hast"
 import { GlobalConfiguration } from "../../cfg"
 import { getDate } from "../../components/Date"
 import { escapeHTML } from "../../util/escape"
-import { FilePath, FullSlug, SimpleSlug, joinSegments, simplifySlug } from "../../util/path"
+import { FilePath, FullSlug, SimpleSlug, joinSegments, simplifySlug, getAllSegmentPrefixes } from "../../util/path"
 import { QuartzEmitterPlugin } from "../types"
 import { toHtml } from "hast-util-to-html"
 import { write } from "./helpers"
@@ -42,10 +42,45 @@ function generateSiteMap(cfg: GlobalConfiguration, idx: ContentIndex): string {
     <loc>https://${joinSegments(base, encodeURI(slug))}</loc>
     ${content.date && `<lastmod>${content.date.toISOString()}</lastmod>`}
   </url>`
-  const urls = Array.from(idx)
+
+  // Get all unique tags from content
+  const tags = new Set<string>()
+  for (const [_, content] of idx) {
+    content.tags.forEach(tag => {
+      // Add all tag segments (for hierarchical tags)
+      getAllSegmentPrefixes(tag).forEach(segment => tags.add(segment))
+    })
+  }
+
+  // Generate URLs for content pages
+  const contentUrls = Array.from(idx)
     .map(([slug, content]) => createURLEntry(simplifySlug(slug), content))
     .join("")
-  return `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">${urls}</urlset>`
+
+  // Generate URLs for tag pages
+  const tagUrls = Array.from(tags)
+    .map(tag => {
+      const tagSlug = `tags/${tag}` as SimpleSlug
+      return createURLEntry(tagSlug, {
+        title: `Tag: ${tag}`,
+        links: [],
+        tags: [],
+        content: "",
+        date: new Date() // Use current date for tag pages
+      })
+    })
+    .join("")
+
+  // Add the main tags index page
+  const tagsIndexUrl = createURLEntry("tags/" as SimpleSlug, {
+    title: "Tags",
+    links: [],
+    tags: [],
+    content: "",
+    date: new Date() // Use current date for tags index
+  })
+
+  return `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">${contentUrls}${tagUrls}${tagsIndexUrl}</urlset>`
 }
 
 function generateRSSFeed(cfg: GlobalConfiguration, idx: ContentIndex, limit?: number): string {

--- a/quartz/plugins/emitters/tagPage.tsx
+++ b/quartz/plugins/emitters/tagPage.tsx
@@ -87,8 +87,8 @@ export const TagPage: QuartzEmitterPlugin<Partial<TagPageOptions>> = (userOpts) 
         [...tags].map((tag) => {
           const title =
             tag === "index"
-              ? i18n(cfg.locale).pages.tagContent.tagIndex
-              : `${i18n(cfg.locale).pages.tagContent.tag}: ${tag}`
+              ? `${cfg.pageTitle}: ${i18n(cfg.locale).pages.tagContent.tagIndex}`
+              : `${cfg.pageTitle}: ${i18n(cfg.locale).pages.tagContent.tag} ${tag}`
           return [
             tag,
             defaultProcessedContent({


### PR DESCRIPTION
- Add tag pages to sitemap with proper URLs | - Update tag page titles to be more descriptive | - Include site name in tag page titles | - Make tag page titles more user-friendly | - Ensure URLs match actual page paths to avoid redirects