### PR TITLE
fix: use modified date in sitemap

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -24,7 +24,7 @@ const config: QuartzConfig = {
       "_obsidian",
       "node_modules",
     ],
-    defaultDateType: "created",
+    defaultDateType: "modified",
     generateSocialImages: false,
     theme: {
       fontOrigin: "googleFonts",


### PR DESCRIPTION
- Changed defaultDateType from 'created' to 'modified' | - Now sitemap.xml uses lastmod dates from frontmatter instead of created dates | - This ensures sitemap reflects the most recent content updates