### PR TITLE
feat: Add related articles component

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -5,7 +5,9 @@ import * as Component from "./quartz/components"
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
-  afterBody: [],
+  afterBody: [
+    Component.RelatedContent(),
+  ],
   footer: Component.Footer({
     links: {},
   }),

--- a/quartz/components/RelatedContent.tsx
+++ b/quartz/components/RelatedContent.tsx
@@ -1,0 +1,118 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { resolveRelative, simplifySlug } from "../util/path"
+import { i18n } from "../i18n"
+import { classNames } from "../util/lang"
+import { FilePath, FullSlug } from "../util/path"
+
+interface RelatedContentOptions {
+  hideIfEmpty: boolean
+  maxArticles: number
+}
+
+const defaultOptions: RelatedContentOptions = {
+  hideIfEmpty: true,
+  maxArticles: 5,
+}
+
+export default ((opts?: Partial<RelatedContentOptions>) => {
+  const options: RelatedContentOptions = { ...defaultOptions, ...opts }
+
+  const RelatedContent: QuartzComponent = ({
+    fileData,
+    allFiles,
+    displayClass,
+    cfg,
+  }: QuartzComponentProps) => {
+    // If no tags, don't show the component
+    const currentTags = fileData.frontmatter?.tags || []
+    if (currentTags.length === 0) {
+      return null
+    }
+    
+    // Get current slug to exclude current article from results
+    const currentSlug = simplifySlug(fileData.slug!)
+    
+    // Find other articles with matching tags
+    const relatedArticles = allFiles
+      .filter((file) => {
+        // Don't include the current article
+        if (simplifySlug(file.slug!) === currentSlug) return false
+        
+        // Check if publish is true
+        if (file.frontmatter?.publish !== true) return false
+        
+        // Check if has shared tags
+        const fileTags = file.frontmatter?.tags || []
+        return fileTags.some(tag => currentTags.includes(tag))
+      })
+      // Sort by number of matching tags (most matches first)
+      .map(file => {
+        const fileTags = file.frontmatter?.tags || []
+        const matchingTagsCount = fileTags.filter(tag => currentTags.includes(tag)).length
+        return { file, matchingTagsCount }
+      })
+      .sort((a, b) => b.matchingTagsCount - a.matchingTagsCount)
+      .map(item => item.file)
+      .slice(0, options.maxArticles)
+
+    if (options.hideIfEmpty && relatedArticles.length === 0) {
+      return null
+    }
+
+    return (
+      <div class={classNames(displayClass, "related-content")}>
+        <h2>{i18n(cfg.locale).components.relatedContent.title}</h2>
+        <ul>
+          {relatedArticles.length > 0 ? (
+            relatedArticles.map((f) => (
+              <li>
+                <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
+                  {f.frontmatter?.title}
+                </a>
+              </li>
+            ))
+          ) : (
+            <li>{i18n(cfg.locale).components.relatedContent.noRelatedContent}</li>
+          )}
+        </ul>
+      </div>
+    )
+  }
+
+  RelatedContent.css = `
+  .related-content {
+    margin: 4rem 0 2rem 0;
+    padding-top: 2rem;
+    border-top: 1px solid var(--lightgray);
+  }
+  
+  .related-content h2 {
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+  }
+  
+  .related-content ul {
+    list-style: disc;
+    padding-left: 1.2rem;
+  }
+  
+  .related-content ul li {
+    margin: 0.5rem 0;
+    padding-left: 0.5rem;
+  }
+
+  .related-content a.internal {
+    font-weight: 500;
+    text-decoration: none;
+    color: var(--secondary);
+    transition: color 0.2s ease;
+  }
+  
+  .related-content a.internal:hover {
+    color: var(--tertiary);
+    text-decoration: underline;
+  }
+  `
+
+  return RelatedContent
+}) satisfies QuartzComponentConstructor 

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -21,6 +21,7 @@ import RecentNotes from "./RecentNotes"
 import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import TagNav from "./TagNav"
+import RelatedContent from "./RelatedContent"
 
 export {
   ArticleTitle,
@@ -37,6 +38,7 @@ export {
   TagList,
   Graph,
   Backlinks,
+  RelatedContent,
   Search,
   Footer,
   DesktopOnly,

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -27,6 +27,10 @@ export interface Translation {
       title: string
       noBacklinksFound: string
     }
+    relatedContent: {
+      title: string
+      noRelatedContent: string
+    }
     themeToggle: {
       lightMode: string
       darkMode: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -25,6 +25,10 @@ export default {
       title: "Backlinks",
       noBacklinksFound: "No backlinks found",
     },
+    relatedContent: {
+      title: "Related Articles",
+      noRelatedContent: "No related articles found",
+    },
     themeToggle: {
       lightMode: "Light mode",
       darkMode: "Dark mode",

--- a/quartz/i18n/locales/ru-RU.ts
+++ b/quartz/i18n/locales/ru-RU.ts
@@ -25,6 +25,10 @@ export default {
       title: "Обратные ссылки",
       noBacklinksFound: "Обратные ссылки отсутствуют",
     },
+    relatedContent: {
+      title: "Похожие статьи",
+      noRelatedContent: "Похожие статьи не найдены",
+    },
     themeToggle: {
       lightMode: "Светлый режим",
       darkMode: "Тёмный режим",


### PR DESCRIPTION
- Add RelatedContent component to display articles with similar tags
- Show articles with matching tags at the bottom of content pages
- Sort articles by number of matching tags
- Add localization for Russian and English
- Add styling for better readability

Это поможет улучшить SEO и навигацию по сайту, предлагая читателям похожие статьи по теме.