### PR TITLE
feat: add Latest Posts section to homepage

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -24,10 +24,17 @@ npx quartz build
 ---
 title: "Title"
 date: 2024-02-08
-tags: [tag1, tag2]
+tags: [tag1, tag2]  # Used for navigation and Related Articles section
 publish: true  # required
 ---
 ```
+
+### Related Articles
+- Appears at the bottom of each article
+- Shows up to 5 articles with matching tags
+- Articles are sorted by number of matching tags
+- Improves SEO and internal linking
+- Automatically hidden if no matching articles found
 
 ## Development
 - Branch from `v4`: `feat/*` or `fix/*`

--- a/.cursorrules
+++ b/.cursorrules
@@ -30,18 +30,16 @@ publish: true  # required
 ```
 
 ### Related Articles
-- Appears at the bottom of each article
-- Shows up to 5 articles with matching tags
-- Articles are sorted by number of matching tags
-- Improves SEO and internal linking
-- Automatically hidden if no matching articles found
+- Implementation: `quartz/components/RelatedContent.tsx`
+- Shows 5 articles with matching tags
+- Sorted by matching tags count
+- Auto-hidden if empty
 
 ### Latest Posts
-- Appears on the homepage (index)
-- Shows 5 most recent published articles
-- Sorted by publication date (newest first)
-- SEO-optimized with h2 heading
-- Improves content discovery and navigation
+- Implementation: `quartz/components/LatestPosts.tsx`
+- Shows 5 recent articles on index
+- Sorted by date (newest first)
+- SEO-optimized h2 heading
 
 ## Development
 - Branch from `v4`: `feat/*` or `fix/*`

--- a/.cursorrules
+++ b/.cursorrules
@@ -36,6 +36,13 @@ publish: true  # required
 - Improves SEO and internal linking
 - Automatically hidden if no matching articles found
 
+### Latest Posts
+- Appears on the homepage (index)
+- Shows 5 most recent published articles
+- Sorted by publication date (newest first)
+- SEO-optimized with h2 heading
+- Improves content discovery and navigation
+
 ## Development
 - Branch from `v4`: `feat/*` or `fix/*`
 - Pull & update submodules before work

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ npx quartz build
   - Sorted by relevance (number of matching tags)
   - Improves navigation and SEO
   - Automatically hidden if no matches found
+- 📅 Latest Posts on Homepage
+  - Shows 5 most recent published articles
+  - Improves content discovery
+  - SEO-optimized with proper heading structure
+  - Automatically updates as new content is added
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx quartz build
   ---
   title: "Page Title"
   date: 2024-02-08
-  tags: [tag1, tag2]
+  tags: [tag1, tag2]  # Used for navigation and Related Articles
   publish: true
   ---
   ```
@@ -74,6 +74,11 @@ npx quartz build
 - 🌙 Dark/Light mode
 - 🧮 LaTeX support
 - 📝 Table of contents generation
+- 📚 Related Articles section
+  - Shows up to 5 articles with matching tags
+  - Sorted by relevance (number of matching tags)
+  - Improves navigation and SEO
+  - Automatically hidden if no matches found
 
 ## Contributing
 

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -6,6 +6,7 @@ export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
   afterBody: [
+    Component.LatestPosts(),
     Component.RelatedContent(),
   ],
   footer: Component.Footer({

--- a/quartz/components/LatestPosts.tsx
+++ b/quartz/components/LatestPosts.tsx
@@ -1,0 +1,109 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { resolveRelative, simplifySlug } from "../util/path"
+import { i18n } from "../i18n"
+import { classNames } from "../util/lang"
+
+interface LatestPostsOptions {
+  hideIfEmpty: boolean
+  maxArticles: number
+  title?: string
+}
+
+const defaultOptions: LatestPostsOptions = {
+  hideIfEmpty: true,
+  maxArticles: 5,
+}
+
+export default ((opts?: Partial<LatestPostsOptions>) => {
+  const options: LatestPostsOptions = { ...defaultOptions, ...opts }
+
+  const LatestPosts: QuartzComponent = ({
+    fileData,
+    allFiles,
+    displayClass,
+    cfg,
+  }: QuartzComponentProps) => {
+    // Only show on index page
+    if (fileData.slug !== "index") {
+      return null
+    }
+    
+    // Find latest published articles by creation date
+    const latestArticles = allFiles
+      .filter((file) => {
+        // Only include published articles
+        return file.frontmatter?.publish === true
+      })
+      // Sort by date (newest first)
+      .sort((a, b) => {
+        const dateA = a.frontmatter?.date ? new Date(a.frontmatter.date as string) : new Date(0)
+        const dateB = b.frontmatter?.date ? new Date(b.frontmatter.date as string) : new Date(0)
+        return dateB.getTime() - dateA.getTime()
+      })
+      .slice(0, options.maxArticles)
+
+    if (options.hideIfEmpty && latestArticles.length === 0) {
+      return null
+    }
+
+    // Use custom title or get from i18n
+    const title = options.title ?? i18n(cfg.locale).components.latestPosts?.title ?? "Latest Posts"
+    const emptyMessage = i18n(cfg.locale).components.latestPosts?.noLatestPosts ?? "No published articles"
+
+    return (
+      <div class={classNames(displayClass, "latest-posts")}>
+        <h2>{title}</h2>
+        <ul>
+          {latestArticles.length > 0 ? (
+            latestArticles.map((f) => (
+              <li>
+                <a href={resolveRelative(fileData.slug!, f.slug!)} class="internal">
+                  {f.frontmatter?.title}
+                </a>
+              </li>
+            ))
+          ) : (
+            <li>{emptyMessage}</li>
+          )}
+        </ul>
+      </div>
+    )
+  }
+
+  LatestPosts.css = `
+  .latest-posts {
+    margin: 4rem 0 2rem 0;
+    padding-top: 2rem;
+    border-top: 1px solid var(--lightgray);
+  }
+  
+  .latest-posts h2 {
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+  }
+  
+  .latest-posts ul {
+    list-style: disc;
+    padding-left: 1.2rem;
+  }
+  
+  .latest-posts ul li {
+    margin: 0.5rem 0;
+    padding-left: 0.5rem;
+  }
+
+  .latest-posts a.internal {
+    font-weight: 500;
+    text-decoration: none;
+    color: var(--secondary);
+    transition: color 0.2s ease;
+  }
+  
+  .latest-posts a.internal:hover {
+    color: var(--tertiary);
+    text-decoration: underline;
+  }
+  `
+
+  return LatestPosts
+}) satisfies QuartzComponentConstructor 

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -22,6 +22,7 @@ import Breadcrumbs from "./Breadcrumbs"
 import Comments from "./Comments"
 import TagNav from "./TagNav"
 import RelatedContent from "./RelatedContent"
+import LatestPosts from "./LatestPosts"
 
 export {
   ArticleTitle,
@@ -48,4 +49,5 @@ export {
   Breadcrumbs,
   Comments,
   TagNav,
+  LatestPosts,
 }

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -31,6 +31,10 @@ export interface Translation {
       title: string
       noRelatedContent: string
     }
+    latestPosts: {
+      title: string
+      noLatestPosts: string
+    }
     themeToggle: {
       lightMode: string
       darkMode: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -29,6 +29,10 @@ export default {
       title: "Related Articles",
       noRelatedContent: "No related articles found",
     },
+    latestPosts: {
+      title: "Latest Posts",
+      noLatestPosts: "No published articles",
+    },
     themeToggle: {
       lightMode: "Light mode",
       darkMode: "Dark mode",

--- a/quartz/i18n/locales/ru-RU.ts
+++ b/quartz/i18n/locales/ru-RU.ts
@@ -29,6 +29,10 @@ export default {
       title: "Похожие статьи",
       noRelatedContent: "Похожие статьи не найдены",
     },
+    latestPosts: {
+      title: "Последние посты",
+      noLatestPosts: "Нет опубликованных статей",
+    },
     themeToggle: {
       lightMode: "Светлый режим",
       darkMode: "Тёмный режим",


### PR DESCRIPTION
Add Latest Posts section to the homepage that shows 5 most recent published articles.

## Features
- Shows 5 most recent published articles on index page
- Sorted by publication date (newest first)
- SEO-optimized with h2 heading
- Supports i18n (English and Russian)
- Auto-hidden if no published articles

## Implementation
- Created LatestPosts.tsx component
- Added i18n support in definition.ts and language files
- Integrated into layout before RelatedContent

## Documentation
- Added feature description to README.md
- Added implementation details to .cursorrules