### PR TITLE
refactor: Simplify component borders

### DIFF
--- a/quartz/components/LatestPosts.tsx
+++ b/quartz/components/LatestPosts.tsx
@@ -72,9 +72,7 @@ export default ((opts?: Partial<LatestPostsOptions>) => {
 
   LatestPosts.css = `
   .latest-posts {
-    margin: 4rem 0 2rem 0;
-    padding-top: 2rem;
-    border-top: 1px solid var(--lightgray);
+    margin: 2rem 0;
   }
   
   .latest-posts h2 {

--- a/quartz/components/RelatedContent.tsx
+++ b/quartz/components/RelatedContent.tsx
@@ -7,6 +7,7 @@ import { FilePath, FullSlug } from "../util/path"
 interface RelatedContentOptions {
   hideIfEmpty: boolean
   maxArticles: number
+  title?: string
 }
 
 const defaultOptions: RelatedContentOptions = {
@@ -23,6 +24,11 @@ export default ((opts?: Partial<RelatedContentOptions>) => {
     displayClass,
     cfg,
   }: QuartzComponentProps) => {
+    // Don't show on index page
+    if (fileData.slug === "index") {
+      return null
+    }
+    
     // If no tags, don't show the component
     const currentTags = fileData.frontmatter?.tags || []
     if (currentTags.length === 0) {
@@ -59,9 +65,13 @@ export default ((opts?: Partial<RelatedContentOptions>) => {
       return null
     }
 
+    // Use custom title or get from i18n
+    const title = options.title ?? i18n(cfg.locale).components.relatedContent?.title ?? "Related Articles"
+    const emptyMessage = i18n(cfg.locale).components.relatedContent?.noRelatedContent ?? "No related articles"
+
     return (
       <div class={classNames(displayClass, "related-content")}>
-        <h2>{i18n(cfg.locale).components.relatedContent.title}</h2>
+        <h2>{title}</h2>
         <ul>
           {relatedArticles.length > 0 ? (
             relatedArticles.map((f) => (
@@ -72,7 +82,7 @@ export default ((opts?: Partial<RelatedContentOptions>) => {
               </li>
             ))
           ) : (
-            <li>{i18n(cfg.locale).components.relatedContent.noRelatedContent}</li>
+            <li>{emptyMessage}</li>
           )}
         </ul>
       </div>
@@ -81,9 +91,7 @@ export default ((opts?: Partial<RelatedContentOptions>) => {
 
   RelatedContent.css = `
   .related-content {
-    margin: 4rem 0 2rem 0;
-    padding-top: 2rem;
-    border-top: 1px solid var(--lightgray);
+    margin: 2rem 0;
   }
   
   .related-content h2 {

--- a/quartz/plugins/transformers/toc.ts
+++ b/quartz/plugins/transformers/toc.ts
@@ -4,6 +4,25 @@ import { visit } from "unist-util-visit"
 import { toString } from "mdast-util-to-string"
 import Slugger from "github-slugger"
 
+// Function to strip HTML tags and decode HTML entities
+function stripHtml(html: string): string {
+  // First remove HTML tags
+  const withoutTags = html.replace(/<[^>]*>/g, '')
+  
+  // Then decode common HTML entities
+  return withoutTags
+    .replace(/&rarr;/g, '→')
+    .replace(/&larr;/g, '←')
+    .replace(/&rArr;/g, '⇒')
+    .replace(/&lArr;/g, '⇐')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+}
+
 export interface Options {
   maxDepth: 1 | 2 | 3 | 4 | 5 | 6
   minEntries: number
@@ -40,7 +59,7 @@ export const TableOfContents: QuartzTransformerPlugin<Partial<Options>> = (userO
               let highestDepth: number = opts.maxDepth
               visit(tree, "heading", (node) => {
                 if (node.depth <= opts.maxDepth) {
-                  const text = toString(node)
+                  const text = stripHtml(toString(node))
                   highestDepth = Math.min(highestDepth, node.depth)
                   toc.push({
                     depth: node.depth,


### PR DESCRIPTION
- Remove border-top from LatestPosts and RelatedContent
- Use global hr separator
- Add title customization option
- Unify margins between components

This PR simplifies the border logic by removing individual component borders and relying on the global hr separator. It also adds the ability to customize component titles and unifies the margins between components for better consistency.