### PR TITLE
fix: Add Schema.org structured data for homepage

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -220,8 +220,46 @@ export default (() => {
           .filter((resource) => resource.loadTime === "beforeDOMReady")
           .map((res) => JSResourceToScriptElement(res, true))}
           
-        {/* Structured data for author using Schema.org */}
-        {fileData.slug !== "index" && (
+        {/* Structured data using Schema.org */}
+        {fileData.slug === "index" ? (
+          <script type="application/ld+json">
+            {JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "WebSite",
+              "name": cfg.pageTitle,
+              "description": description,
+              "url": url.toString().replace(/\/$/, ""),
+              "author": {
+                "@type": "Person",
+                "@id": "https://kirill-markin.com",
+                "name": "Kirill Markin",
+                "url": "https://kirill-markin.com",
+                "sameAs": [
+                  "https://x.com/kirill_markin_",
+                  "https://github.com/kirill-markin",
+                  "https://www.linkedin.com/in/kirill-markin/"
+                ]
+              },
+              "publisher": {
+                "@type": "Person", 
+                "@id": "https://kirill-markin.com",
+                "name": "Kirill Markin",
+                "logo": {
+                  "@type": "ImageObject",
+                  "url": `https://${cfg.baseUrl}/static/icon.png`
+                }
+              },
+              "potentialAction": {
+                "@type": "SearchAction",
+                "target": {
+                  "@type": "EntryPoint",
+                  "urlTemplate": `https://${cfg.baseUrl}/?q={search_term_string}`
+                },
+                "query-input": "required name=search_term_string"
+              }
+            })}
+          </script>
+        ) : (
           <script type="application/ld+json">
             {JSON.stringify({
               "@context": "https://schema.org",


### PR DESCRIPTION
## Overview

This PR adds structured data (Schema.org) to the homepage, which was previously missing.

## Changes

- Add WebSite schema markup specifically for the homepage
- Maintain existing Article schema for all content pages
- Improve SEO performance by providing appropriate structured data for all pages

## Test Plan

To verify these changes:
1. Build the site with `npx quartz build`
2. Check homepage source code for presence of schema.org JSON-LD data
3. Validate structured data using Google's Structured Data Testing Tool

This addresses an SEO optimization issue where the homepage was missing appropriate structured data markup.